### PR TITLE
fixing imports in univa_engine.py

### DIFF
--- a/src/steamroller/engines/univa_engine.py
+++ b/src/steamroller/engines/univa_engine.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import logging
+import shlex
 from .grid_engine import GridEngine
 
 #def univa(commands, name, std, dep_ids=[], grid_resources=[], working_dir=None, queue="all.q"):
@@ -10,7 +14,7 @@ def univa(commands, name, std, dep_ids=[], working_dir=None, gpu_count=0, time="
         except:
             pass
     deps = "" if len(dep_ids) == 0 else "-hold_jid {}".format(",".join([str(x) for x in dep_ids]))
-    res = "" if len(grid_resources) == 0 else "-l {}".format(",".join([str(x) for x in grid_resources]))
+    #res = "" if len(grid_resources) == 0 else "-l {}".format(",".join([str(x) for x in grid_resources]))
     wd = "-wd {}".format(working_dir) if working_dir else "-cwd"
     qcommand = "qsub -terse -shell n -V -N {} -q {} -b n {} {} -j y -o {} -l h_rt={},mem_free={}".format(name, queue, wd, deps, std, time, memory)
     logging.info("\n".join(commands))


### PR DESCRIPTION
When using steamroller for SLURM, I found that ```univa_engine.py``` is missing a few imports which prevent steamroller from using any engine other than local. This pull request:
* adds import statements for os, logging, subprocess, and shlex, which are called in the script
* comments out an unused line with reference to a variable ```grid_resources```, which is not defined in the current version of the univa_engine.py script