### PR TITLE
Adding support for Accelerate launch

### DIFF
--- a/src/steamroller/engines/grid_engine.py
+++ b/src/steamroller/engines/grid_engine.py
@@ -102,8 +102,9 @@ class GridEngine(ABC):
         
         commands = builder.action.presub_lines(env)
         chdir = builder.action.chdir
+        
+        m = re.match(r"^\s*((?:\S*[Pp]ython3?)|(?:accelerate launch))\s+(.*?\.py)\s+(.*)$", commands[0])
 
-        m = re.match(r"^\s*(\S*[Pp]ython3?)\s+(.*?\.py)\s+(.*)$", commands[0])
         if not m:
             raise Exception("Could not parse command: '{}'".format(commands[0]))
         

--- a/src/steamroller/engines/local_engine.py
+++ b/src/steamroller/engines/local_engine.py
@@ -22,6 +22,7 @@ class LocalEngine(GridEngine):
         commands = builder.action.presub_lines(env)
         chdir = builder.action.chdir
 
+        #m = re.match(r"^\s*(\S*[Pp]ython3?)\s+(.*?\.py)\s+(.*)$", commands[0])
         m = re.match(r"^\s*((?:\S*[Pp]ython3?)|(?:accelerate launch))\s+(.*?\.py)\s+(.*)$", commands[0])
         if not m:
             raise Exception("Could not parse command: '{}'".format(commands[0]))

--- a/src/steamroller/engines/local_engine.py
+++ b/src/steamroller/engines/local_engine.py
@@ -22,7 +22,7 @@ class LocalEngine(GridEngine):
         commands = builder.action.presub_lines(env)
         chdir = builder.action.chdir
 
-        m = re.match(r"^\s*(\S*[Pp]ython3?)\s+(.*?\.py)\s+(.*)$", commands[0])
+        m = re.match(r"^\s*((?:\S*[Pp]ython3?)|(?:accelerate launch))\s+(.*?\.py)\s+(.*)$", commands[0])
         if not m:
             raise Exception("Could not parse command: '{}'".format(commands[0]))
         

--- a/src/steamroller/engines/univa_engine.py
+++ b/src/steamroller/engines/univa_engine.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import logging
+import shlex
 from .grid_engine import GridEngine
 
 #def univa(commands, name, std, dep_ids=[], grid_resources=[], working_dir=None, queue="all.q"):
@@ -10,7 +14,7 @@ def univa(commands, name, std, dep_ids=[], working_dir=None, gpu_count=0, time="
         except:
             pass
     deps = "" if len(dep_ids) == 0 else "-hold_jid {}".format(",".join([str(x) for x in dep_ids]))
-    res = "" if len(grid_resources) == 0 else "-l {}".format(",".join([str(x) for x in grid_resources]))
+    #res = "" if len(grid_resources) == 0 else "-l {}".format(",".join([str(x) for x in grid_resources]))
     wd = "-wd {}".format(working_dir) if working_dir else "-cwd"
     qcommand = "qsub -terse -shell n -V -N {} -q {} -b n {} {} -j y -o {} -l h_rt={},mem_free={}".format(name, queue, wd, deps, std, time, memory)
     logging.info("\n".join(commands))


### PR DESCRIPTION
In this pull request, I modify the regex found in ```src/steamroller/engines/local_engine.py``` and ```src/steamroller/engines/slurm_engine.py``` to allow for launching either with Python or with 'accelerate launch' to allow compatibility with the [accelerate](https://huggingface.co/docs/accelerate/basic_tutorials/launch) module for multi-GPU training/inference.

N.B. ```accelerate config``` should still be run prior to launching scripts, as this regex does not parse additional command line arguments given to accelerate, such as ```--num_processes```.

```
# old
m = re.match(r"^\s*(\S*[Pp]ython3?)\s+(.*?\.py)\s+(.*)$", commands[0])
# new
m = re.match(r"^\s*((?:\S*[Pp]ython3?)|(?:accelerate launch))\s+(.*?\.py)\s+(.*)$", commands[0])
```