### PR TITLE
removing implicit dependencies and patching 'slurm' action contents

### DIFF
--- a/src/steamroller/engines/grid_engine.py
+++ b/src/steamroller/engines/grid_engine.py
@@ -112,12 +112,18 @@ class GridEngine(ABC):
             raise Exception("No such file: '{}'".format(script))
         
         generator = self.create_generator(commands)
-
-        return Builder(
-            action=Action(
+        action = Action(
                 create_method(generator, chdir, self.submit_string),
                 self.create_command_printer(generator),
-            ),
+            )
+        def get_contents(target, source, env):
+            commands = generator(target, source, env, False)
+            action = Action(commands)
+            return action.get_contents(target, source, env)
+        action.gc = get_contents
+
+        return Builder(
+            action=action,
             emitter=self.create_emitter(script),
         )
     

--- a/src/steamroller/environment.py
+++ b/src/steamroller/environment.py
@@ -46,7 +46,8 @@ class Environment(Base):
             ("STEAMROLLER_NAME_PREFIX", "", "steamroller"),
             ("STEAMROLLER_SUBMIT_COMMAND", "", None),
             ("STEAMROLLER_SHELL", "", "#!/bin/bash"),
-            ListVariable("STEAMROLLER_NOOPS", help="Treat the specified build rules as no-ops/passthroughs.", default=[], names=list(builders.keys()))
+            ListVariable("STEAMROLLER_NOOPS", help="Treat the specified build rules as no-ops/passthroughs.", default=[], names=list(builders.keys())),
+            ("IMPLICIT_COMMAND_DEPENDENCIES", "", False)
         )
         tools = argd.pop("tools", [])
         


### PR DESCRIPTION
Implements the 'potential fixes' as described in #6.
Specifically:
Normalise both actions to not include the python interpreter as a dependency by adding the following to Variables:

Make the slurm action content mirror to the local action get_contents function. This makes slurm actions sensitive to input arg changes (fixes missed rebuilds).